### PR TITLE
Include build trigger id in request

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,14 +33,17 @@
     <script src="/dist/datocms-search.widget.js"></script>
     <script>
       var client = new DatoCmsSearch("b293db3654076d696e954f8788d510");
+      // Add build trigger id in props object if search is based on build
+      var props = {
+        locales: [
+          { label: "English", value: "en" },
+          { label: "Italian", value: "it" },
+        ]
+      };
+
       client.addWidget(
         "#search-container",
-        {
-          locales: [
-            { label: "English", value: "en" },
-            { label: "Italian", value: "it" },
-          ]
-        }
+        props
       );
     </script>
   </body>

--- a/src/base.js
+++ b/src/base.js
@@ -30,7 +30,12 @@ DatoCmsSearch.prototype = {
 
     var url = 'https://site-api.datocms.com/search-results?';
     url += 'q=' + encodeURIComponent(query);
-    url += '&environment=' + encodeURIComponent(this.environment);
+
+    if (options.buildTriggerId) {
+      url += '&build_trigger_id=' + encodeURIComponent(options.buildTriggerId);
+    } else {
+      url += '&environment=' + encodeURIComponent(this.environment);
+    }
 
     if (options.locale) {
       url += '&locale=' + encodeURIComponent(options.locale);

--- a/src/widget.js
+++ b/src/widget.js
@@ -16,6 +16,7 @@ class SearchComponent extends Component {
       locale: props.initialLocale || (props.locales ? props.locales[0].value : null),
       page: 0,
       isLocaleOpen: false,
+      buildTriggerId: props.buildTriggerId
     };
 
     this.handleClickOutside = this.handleClickOutside.bind(this);
@@ -72,6 +73,7 @@ class SearchComponent extends Component {
         offset: this.state.page * this.props.perPage,
         limit: this.props.perPage,
         locale: this.state.locale,
+        buildTriggerId: this.state.buildTriggerId
       }
     )
       .then(({ results, total }) => {


### PR DESCRIPTION
This PR is for including `build_trigger_id` while making GET request.

Reference for this implementation is here https://www.datocms.com/docs/content-management-api/resources/search-result/instances